### PR TITLE
Fix typo and update references in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,6 @@ ggplot(volcano, aes(x = x, y = y, fill = height)) +
 
 -   Crameri, Fabio. (2021, September 12). *Scientific colour maps (Version
     7.0.1)*. Zenodo. doi: 10.5281/zenodo.5501399   
-    
 -   Crameri, Fabio. (2018). *Geodynamic diagnostics, scientific
     visualisation and StagLab 3.0*. Geosci. Model Dev. Discuss. doi:
     10.5194/gmd-2017-328

--- a/README.md
+++ b/README.md
@@ -77,8 +77,9 @@ ggplot(volcano, aes(x = x, y = y, fill = height)) +
 
 ## References
 
--   Crameri, Fabio. (2018, May 8). *Scientific colour maps (Version
-    3.0.1)*. Zenodo. doi: 10.5281/zenodo.1243909
+-   Crameri, Fabio. (2021, September 12). *Scientific colour maps (Version
+    7.0.1)*. Zenodo. doi: 10.5281/zenodo.5501399   
+    
 -   Crameri, Fabio. (2018). *Geodynamic diagnostics, scientific
     visualisation and StagLab 3.0*. Geosci. Model Dev. Discuss. doi:
     10.5194/gmd-2017-328

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ devtools::install_github("thomasp85/scico")
 
 ## Palettes
 
-`scico` provides 17 different palettes, all of which are perceptually
+`scico` provides 35 different palettes, all of which are perceptually
 uniform and colourblind safe. An overview can be had with the
 `scico_palette_show()` function:
 


### PR DESCRIPTION
Fixes 2 issues:

* The number of available palettes is 35, in the README still the old value of 17 is used.
* Update references to latest release